### PR TITLE
Fix Errors that made system unusable

### DIFF
--- a/XPSystem/EventHandlers/LoaderSpecific/ExiledEventHandlers.cs
+++ b/XPSystem/EventHandlers/LoaderSpecific/ExiledEventHandlers.cs
@@ -1,4 +1,4 @@
-﻿namespace XPSystem.EventHandlers.LoaderSpecific
+namespace XPSystem.EventHandlers.LoaderSpecific
 {
     using System;
     using Exiled.Events.EventArgs.Interfaces;
@@ -120,7 +120,12 @@
         }
 
         private void PlayerUsedItem(UsedItemEventArgs ev) => OnPlayerUsedItem(ev.Player, ev.Item.Type);
-        private void PlayerSpawned(SpawnedEventArgs ev) => OnPlayerSpawned(ev.Player);
+        private void PlayerSpawned(SpawnedEventArgs ev)
+        {
+            if (!ev.Player.IsVerified)
+                return;
+            OnPlayerSpawned(ev.Player);
+        }
 
         private void PlayerEscaping(EscapingEventArgs ev)
         {


### PR DESCRIPTION
Since last exiled update this caused errors that made everyone have 0 Levels and stuff like that. Reason was that the XPPlayer was constructed before UserID was there due to authentication.

Unfortunately, I cant confirm nor deny if this might be necessary for NorwoodAPI too